### PR TITLE
chore: add composer validate & normalize CI check

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,0 +1,12 @@
+{
+    "additional_checks": [
+        {
+            "name": "Composer validate & normalize",
+            "job": {
+                "php": "@lowest",
+                "dependencies": "latest",
+                "command": "composer validate --strict && composer normalize --dry-run --diff"
+            }
+        }
+    ]
+}

--- a/composer.json
+++ b/composer.json
@@ -1,37 +1,43 @@
 {
-  "name": "silarhi/caf-parser",
-  "description": "A CAF Parser for LA44ZZ file",
-  "license": "MIT",
-  "type": "library",
-  "keywords": [
-    "caf",
-    "parser",
-    "LA44ZZ"
-  ],
-  "authors": [
-    {
-      "name": "SILARHI",
-      "email": "hello@silarhi.fr"
+    "name": "silarhi/caf-parser",
+    "description": "A CAF Parser for LA44ZZ file",
+    "license": "MIT",
+    "type": "library",
+    "keywords": [
+        "caf",
+        "parser",
+        "LA44ZZ"
+    ],
+    "authors": [
+        {
+            "name": "SILARHI",
+            "email": "hello@silarhi.fr"
+        }
+    ],
+    "require": {
+        "php": ">=8.2"
+    },
+    "require-dev": {
+        "ergebnis/composer-normalize": "^2.52",
+        "friendsofphp/php-cs-fixer": "^3.94",
+        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan-strict-rules": "^2.0",
+        "phpunit/phpunit": "^11.5 || ^12.0 || ^13.0",
+        "rector/rector": "^2.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Silarhi\\Caf\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Silarhi\\Caf\\Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "ergebnis/composer-normalize": true
+        }
     }
-  ],
-  "require": {
-    "php": ">=8.2"
-  },
-  "require-dev": {
-    "friendsofphp/php-cs-fixer": "^3.94",
-    "phpstan/phpstan": "^2",
-    "phpstan/phpstan-strict-rules": "^2.0",
-    "phpunit/phpunit": "^11.5|^12|^13",
-    "rector/rector": "^2"
-  },
-  "autoload": {
-    "psr-4": {
-      "Silarhi\\Caf\\": "src/"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Silarhi\\Caf\\Tests\\": "tests/"
-    }
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.52",
-        "friendsofphp/php-cs-fixer": "^3.94",
-        "phpstan/phpstan": "^2.0",
-        "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^11.5 || ^12.0 || ^13.0",
-        "rector/rector": "^2.0"
+        "friendsofphp/php-cs-fixer": "^3.95.7",
+        "phpstan/phpstan": "^2.2.2",
+        "phpstan/phpstan-strict-rules": "^2.0.11",
+        "phpunit/phpunit": "^11.5.55 || ^12.0 || ^13.0",
+        "rector/rector": "^2.4.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
     "config": {
         "allow-plugins": {
             "ergebnis/composer-normalize": true
-        }
+        },
+        "sort-packages": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "allow-plugins": {
             "ergebnis/composer-normalize": true
         },
+        "bump-after-update": "dev",
         "sort-packages": true
     }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   },
   "lint-staged": {
     "*.md": "prettier --write",
-    "*.php": "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php"
+    "*.php": "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php",
+    "composer.json": "composer normalize"
   },
   "scripts": {
     "prepare": "husky"


### PR DESCRIPTION
Adds composer.json quality enforcement, consistent with `silarhi/picasso-bundle`:

- `ergebnis/composer-normalize` dev dependency + its `allow-plugins` entry
- lint-staged hook running `composer normalize` on `composer.json`
- new `.laminas-ci.json` `additional_checks` step running `composer validate --strict && composer normalize --dry-run --diff`
- `config.sort-packages` enabled (separate commit)

Branched fresh off `main` (the previous `chore/composer-quality` was stale).
